### PR TITLE
Update 01b-docker.md

### DIFF
--- a/_episodes/01b-docker.md
+++ b/_episodes/01b-docker.md
@@ -45,9 +45,16 @@ The following setup is based on the Hackathon setup [here](https://gitlab.cern.c
 ## Quick start
 To get started, get the tools with:
 
+From within CERN:
 ~~~
 git clone ssh://git@gitlab.cern.ch:7999/lhcb/upgrade-hackathon-setup.git hackathon
 ~~~
+
+externally from CERN:
+~~~
+git clone https://gitlab.cern.ch/lhcb/upgrade-hackathon-setup.git hackathon
+~~~
+
 {: .input}
 
 > ## Using your ssh key inside the container


### PR DESCRIPTION
Just running through this to setup a docker container to avoid throwing up a full VM to do some work.

I hit a problem, externally to CERN, the URL (command) wrapped in the PR will hang due to the firewall.

This PR is just adding a URL that works externally from CERN so that external users don't have to do proxy-ing.

Not sure if there is a policy on this but new users won't be overly familiar with why things like this don't work from their home institute or on their laptop.